### PR TITLE
Fix progress bar, make public function names available to client

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,1 +1,2 @@
 Hendrik Ballhausen (https://github.com/Ballhausen)
+Uday Nakade (https://github.com/UNakade)

--- a/server/bus.py
+++ b/server/bus.py
@@ -19,7 +19,8 @@ class Bus:
     def list_microservices(self):
         result = []
         for uuid, microservice in self.microservices.items():
-            result.append({'identifiers': microservice['identifiers']})
+            result.append({'identifiers': microservice['identifiers'],
+                           'public_functions': list(microservice['public'].keys())})
         return result
 
     def select_microservice(self, requirements):
@@ -44,14 +45,12 @@ class Bus:
             raise fdrtd.server.exceptions.MicroserviceNotFound(handle)
         microservice = self.microservices[handle]
 
-        if function in microservice['instance'].make_public():
-            fn = microservice['instance'].make_public()[function]
-        elif function in microservice.get('public', {}):
-            fn = getattr(microservice['instance'], function)
+        if function in microservice['public']:
+            fn = microservice['public'][function]
         elif public:
-            raise fdrtd.server.exceptions.FunctionNotPublic(function)
-        elif hasattr(microservice['instance'], function):
-            fn = getattr(microservice['instance'], function)
+            raise fdrtd_server.exceptions.FunctionNotPublic(function)
+        elif function in microservice['private']:
+            fn = microservice['private'][function]
         else:
             raise fdrtd.server.exceptions.FunctionNotFound(function)
 

--- a/server/bus.py
+++ b/server/bus.py
@@ -48,7 +48,7 @@ class Bus:
         if function in microservice['public']:
             fn = microservice['public'][function]
         elif public:
-            raise fdrtd_server.exceptions.FunctionNotPublic(function)
+            raise fdrtd.server.exceptions.FunctionNotPublic(function)
         elif function in microservice['private']:
             fn = microservice['private'][function]
         else:

--- a/server/discovery.py
+++ b/server/discovery.py
@@ -19,10 +19,19 @@ def discover_microservices(path, bus):
                     spec.loader.exec_module(mod)
                     uuid = str(_uuid.uuid4())
                     cls = getattr(mod, ms['classname'], None)
+                    instance = cls(bus, uuid)
+                    public = instance.make_public()
+                    if 'public' in ms:
+                        public.update({function: getattr(instance, function) for function in ms['public']})
+                    private = {}
+                    for attr in dir(instance):
+                        if ('__' not in attr) and (callable(getattr(instance, attr))) and (attr not in public):
+                            private[attr] = getattr(instance, attr)
                     microservices[uuid] = {
                         **ms,
                         'class': cls,
-                        'instance': cls(bus, uuid),
-                        'public': ms['public']
+                        'instance': instance,
+                        'public': public,
+                        'private': private
                     }
     return microservices


### PR DESCRIPTION
Earlier, the make_public function of the microservices was called each time the microservice was called, because the pointers to functions were not being stored in bus.microservices[microservice_handle]. Now, bus.microservices[microservice_handle] stores two dictionaries called 'public' and 'private', which store the function names as well as the pointers. This works because we have only one instance of each microservice running on the server at any given time, so the function pointers stored in these dictionaries will be bound to that instance.
Also, list_microservices called by the client returns a list of public functions along with the microservice identifiers.