### PR TITLE
Fix return of bus.list_representations

### DIFF
--- a/fdrtd/webserver/controllers/default_controller.py
+++ b/fdrtd/webserver/controllers/default_controller.py
@@ -10,7 +10,7 @@ def list_representations():
     """list available server-side objects"""
     try:
         response = get_bus().list_representations()
-        return response, 200  # OK
+        return {'type': 'list', 'list': response}, 200  # OK
     except Exception as exception:
         return handle_exception(exception)
 


### PR DESCRIPTION
This is a very minor thing. On the client side, in the representation package, the api.list function was trying to get list_representations_return_value['list'] but the return value was not a dictionary, but the required list itself. So either this change needs to be added, or the representation package needs to be changed